### PR TITLE
First pass at external configuration

### DIFF
--- a/pcs-where-is/.gitignore
+++ b/pcs-where-is/.gitignore
@@ -1,0 +1,2 @@
+config.py
+__pycache__

--- a/pcs-where-is/config.py.org
+++ b/pcs-where-is/config.py.org
@@ -1,0 +1,20 @@
+CONFIG = {}
+CONFIG['STACKS'] = {
+    'API': {
+        'url':        'https://api.prismacloud.io',
+        'access_key': None,
+        'secret_key': None
+    },
+    'API2': {
+        'url':        'https://api2.prismacloud.io',
+        'access_key': None,
+        'secret_key': None
+    },
+    'API3': {
+        'url':        'https://api3.prismacloud.io',
+        'access_key': None,
+        'secret_key': None
+    }
+    # Add dictionaries for additional stacks here.
+}
+

--- a/pcs-where-is/config.py.org
+++ b/pcs-where-is/config.py.org
@@ -14,7 +14,11 @@ CONFIG['STACKS'] = {
         'url':        'https://api3.prismacloud.io',
         'access_key': None,
         'secret_key': None
+    },
+    'APPEU': {
+        'url':        'https://api.eu.prismacloud.io',
+        'access_key': None,
+        'secret_key': None
     }
     # Add dictionaries for additional stacks here.
 }
-

--- a/pcs-where-is/pcs-where-is.py
+++ b/pcs-where-is/pcs-where-is.py
@@ -132,7 +132,11 @@ except ImportError:
     output('Error reading config')
     exit(1)
 
-if (CONFIG['STACKS']['API']['access_key'] == None):
+configured = False
+for stack in CONFIG['STACKS']:
+    if CONFIG['STACKS'][stack]['access_key'] != None: configured = True
+
+if (not configured):
     output("It appears you haven't configured credentials to access the Prisma Cloud stacks. Copy config.py.org to config.py and put them into your config.py file")
     exit(1)
 

--- a/pcs-where-is/pcs-where-is.py
+++ b/pcs-where-is/pcs-where-is.py
@@ -39,34 +39,6 @@ def output(output_data=''):
     print(output_data)
 
 ##########################################################################################
-# Configure.
-##########################################################################################
-
-def configure(args):
-    config = {}
-    config['CA_BUNDLE'] = args.ca_bundle
-    config['CUSTOMER_NAME'] = args.customer_name
-    config['STACKS'] = {
-        'API': {
-            'url':        'https://api.prismacloud.io',
-            'access_key': os.environ.get('API_ACCESS_KEY', None),
-            'secret_key': os.environ.get('API_SECRET_KEY', None)
-        },
-        'API2': {
-            'url':        'https://api2.prismacloud.io',
-            'access_key': os.environ.get('API2_ACCESS_KEY', None),
-            'secret_key': os.environ.get('API2_SECRET_KEY', None)
-        },
-        'API3': {
-            'url':        'https://api3.prismacloud.io',
-            'access_key': os.environ.get('API3_ACCESS_KEY', None),
-            'secret_key': os.environ.get('API3_SECRET_KEY', None)
-        }
-        # Add dictionaries for additional stacks here.
-    }
-    return config
-
-##########################################################################################
 # Helpers.
 ##########################################################################################
 
@@ -153,7 +125,19 @@ def find_customer(stack, tenants, customer_name, url, ca_bundle, token):
 ## Main.
 ##########################################################################################
 
-CONFIG = configure(args)
+CONFIG = {}
+try:
+    from config import *
+except ImportError:
+    output('Error reading config')
+    exit(1)
+
+if (CONFIG['STACKS']['API']['access_key'] == None):
+    output("It appears you haven't configured credentials to access the Prisma Cloud stacks. Copy config.py.org to config.py and put them into your config.py file")
+    exit(1)
+
+CONFIG['CA_BUNDLE'] = args.ca_bundle
+CONFIG['CUSTOMER_NAME'] = args.customer_name
 
 found = 0
 


### PR DESCRIPTION
With config in a separate file, it makes it easier to run without having set env variables ahead of time. Also it's easier to keep with changes to the code since your config won't be overridden. 

Note that this eliminates the option of passing keys from the environment and I can add that back if necessary. 